### PR TITLE
Apply Same Json Serialization Dictionary<,> Fix

### DIFF
--- a/src/Serilog.Sinks.AzureAnalytics/Sinks/Extensions/LogEventExtensions.cs
+++ b/src/Serilog.Sinks.AzureAnalytics/Sinks/Extensions/LogEventExtensions.cs
@@ -80,12 +80,17 @@ namespace Serilog.Sinks.Extensions
                 return value.Value;
 
             // ReSharper disable once SuspiciousTypeConversion.Global
-            var dictValue = data as IReadOnlyDictionary<string, LogEventPropertyValue>;
+            var dictValue = data as DictionaryValue;
             if (dictValue != null)
             {
                 var expObject = new ExpandoObject() as IDictionary<string, object>;
-                foreach (var item in dictValue.Keys)
-                    expObject.Add(item, Simplify(dictValue[item]));
+                foreach (var item in dictValue.Elements)
+                {
+                    var key = item.Key.Value as string;
+
+                    if(key != null)
+                        expObject.Add(key, Simplify(item.Value));
+                }
                 return expObject;
             }
 


### PR DESCRIPTION
Serilog.Sinks.AzureDocumentDb had a [fix applied](https://github.com/serilog/serilog-sinks-azuredocumentdb/pull/47), and this library is susceptible to the same bug.
