### PR TITLE
Fix maximum message size limit

### DIFF
--- a/src/Serilog.Sinks.AzureAnalytics/Sinks/AzureAnalytics/AzureLogAnalyticsSink.cs
+++ b/src/Serilog.Sinks.AzureAnalytics/Sinks/AzureAnalytics/AzureLogAnalyticsSink.cs
@@ -45,7 +45,7 @@ namespace Serilog.Sinks
         private readonly JsonSerializer _jsonSerializer;
         private readonly JsonSerializerSettings _jsonSerializerSettings;
         private static readonly HttpClient Client = new HttpClient();
-        private static readonly int MaximumMessageSize = 32000000;
+        private static readonly int MaximumMessageSize = 30000000;
 
         internal AzureLogAnalyticsSink(string workSpaceId, string authenticationId, ConfigurationSettings settings) :
             base(settings.BatchSize, settings.BufferSize)


### PR DESCRIPTION
According to docs limit should be 30MB (or a little less for safety). As discussed in https://github.com/saleem-mirza/serilog-sinks-azure-analytics/issues/35#issuecomment-428530150