### PR TITLE
Fix for stack trace issue in case of exception rethrowing

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: '{build}'
 skip_tags: true
-image: Visual Studio 2017
+image: Visual Studio 2019
 configuration: Release
 install:
   - ps: mkdir -Force ".\build\" | Out-Null
@@ -16,7 +16,7 @@ artifacts:
 deploy:
 - provider: NuGet
   api_key:
-    secure: kVO26JLB0/4LwRMAraBZagHoLJPBJxgbYYCEP8PnC0Th74cGwzQijhIqIbl1lmjy
+    secure: eAx6p4jGnLQdaIC70xGHFejyS2GVoxG8krFGV/8W5jATvie1kF5/boNxPumHCL1n
   skip_symbols: true
   on:
     branch: /^(master)$/

--- a/src/Serilog.Sinks.AzureAnalytics/Serilog.Sinks.AzureAnalytics.csproj
+++ b/src/Serilog.Sinks.AzureAnalytics/Serilog.Sinks.AzureAnalytics.csproj
@@ -10,12 +10,12 @@
         <PackageProjectUrl>https://github.com/saleem-mirza/serilog-sinks-azure-analytics</PackageProjectUrl>
         <RepositoryUrl>https://github.com/saleem-mirza/serilog-sinks-azure-analytics</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
-        <Copyright>Copyright © Zethian Inc. 2013-2020</Copyright>
+        <Copyright>Copyright © Zethian Inc. 2013-2021</Copyright>
         <AssemblyVersion>4.7.0.0</AssemblyVersion>
         <Version>4.7.0</Version>
         <SignAssembly>True</SignAssembly>
         <AssemblyOriginatorKeyFile>Serilog.snk</AssemblyOriginatorKeyFile>
-        <TargetFrameworks>netstandard1.3;netcoreapp3.1;net452</TargetFrameworks>
+        <TargetFrameworks>netstandard1.3;netcoreapp3.1;net5.0;net452</TargetFrameworks>
         <RootNamespace>Serilog</RootNamespace>
     </PropertyGroup>
     <PropertyGroup>
@@ -31,7 +31,7 @@
         <Version>$(Version)-$(VersionSuffix)</Version>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Serilog" Version="2.9.0" />
+        <PackageReference Include="Serilog" Version="2.10.0" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
     </ItemGroup>

--- a/src/Serilog.Sinks.AzureAnalytics/Sinks/AzureAnalytics/AzureLogAnalyticsSink.cs
+++ b/src/Serilog.Sinks.AzureAnalytics/Sinks/AzureAnalytics/AzureLogAnalyticsSink.cs
@@ -84,7 +84,7 @@ namespace Serilog.Sinks
             }
 
             _jsonSerializerSettings.ReferenceLoopHandling = ReferenceLoopHandling.Ignore;
-            _jsonSerializerSettings.PreserveReferencesHandling = PreserveReferencesHandling.Objects;
+            _jsonSerializerSettings.PreserveReferencesHandling = PreserveReferencesHandling.None;
             _jsonSerializerSettings.Formatting = Newtonsoft.Json.Formatting.None;
 
             _jsonSerializer = new JsonSerializer {

--- a/src/Serilog.Sinks.AzureAnalytics/Sinks/Extensions/LogEventExtensions.cs
+++ b/src/Serilog.Sinks.AzureAnalytics/Sinks/Extensions/LogEventExtensions.cs
@@ -25,7 +25,10 @@ namespace Serilog.Sinks.Extensions
     {
         internal static string Json(this LogEvent logEvent, bool storeTimestampInUtc = false)
         {
-            return JsonConvert.SerializeObject(ConvertToDictionary(logEvent, storeTimestampInUtc));
+            return JsonConvert.SerializeObject(ConvertToDictionary(logEvent, storeTimestampInUtc), new JsonSerializerSettings {
+                ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
+                NullValueHandling = NullValueHandling.Ignore
+            });
         }
 
         internal static IDictionary<string, object> Dictionary(
@@ -38,7 +41,10 @@ namespace Serilog.Sinks.Extensions
 
         internal static string Json(this IReadOnlyDictionary<string, LogEventPropertyValue> properties)
         {
-            return JsonConvert.SerializeObject(ConvertToDictionary(properties));
+            return JsonConvert.SerializeObject(ConvertToDictionary(properties), new JsonSerializerSettings {
+                ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
+                NullValueHandling = NullValueHandling.Ignore
+            });
         }
 
         internal static IDictionary<string, object> Dictionary(


### PR DESCRIPTION
Because of the delayed sending of batches, there was a problem when exception stack traces could have been overwritten during the delay. Fixed by serializing events immediately on emit. 