### PR TITLE
Add support time-generated-field and x-ms-AzureResourceId headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ This sink accepts following optional configuration parameters for fine grained c
 
 > `flattenObject`: Flag to set if complex object in LogProperties should be flatten out or embed as JSON object. Default is True.
 
+> `setTimeGeneratedFromTimestamp`: Set the time-generated-field header to be Timestamp and not the time that the message is ingested.
+
+> `resourceId`: Set the resource ID of the Azure resource that the data should be associated with using the x-ms-AzureResourceId header.
+
 ```C#
 var logger = new LoggerConfiguration()
     .WriteTo.AzureLogAnalytics(<workspaceId>, <authenticationId>)

--- a/src/Serilog.Sinks.AzureAnalytics/LoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.AzureAnalytics/LoggerConfigurationExtensions.cs
@@ -100,6 +100,8 @@ namespace Serilog
         /// A switch allowing the pass-through minimum level to be changed at runtime.
         /// </param>
         /// <param name="flattenObject">Flat out complex object into simple object. All nested properties will move to root level with computed names</param>
+        /// <param name="setTimeGeneratedFromTimestamp">Set the time-generated-field header to be Timestamp and not the time that the message is ingested.</param>
+        /// <param name="resourceId">Set the resource ID of the Azure resource that the data should be associated with using the x-ms-AzureResourceId header.</param>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration AzureAnalytics(
             this LoggerSinkConfiguration loggerConfiguration,
@@ -113,7 +115,9 @@ namespace Serilog
             int batchSize = 100,
             AzureOfferingType azureOfferingType = AzureOfferingType.Public,
             LoggingLevelSwitch levelSwitch = null,
-            bool flattenObject = true)
+            bool flattenObject = true,
+            bool setTimeGeneratedFromTimestamp = false,
+            string resourceId = null)
         {
             if (string.IsNullOrEmpty(workspaceId))
                 throw new ArgumentNullException(nameof(workspaceId));
@@ -130,7 +134,9 @@ namespace Serilog
                     logBufferSize,
                     batchSize,
                     azureOfferingType,
-                    flattenObject),
+                    flattenObject,
+                    setTimeGeneratedFromTimestamp,
+                    resourceId),
                 restrictedToMinimumLevel,
                 levelSwitch);
         }

--- a/src/Serilog.Sinks.AzureAnalytics/Sinks/AzureAnalytics/AzureLogAnalyticsSink.cs
+++ b/src/Serilog.Sinks.AzureAnalytics/Sinks/AzureAnalytics/AzureLogAnalyticsSink.cs
@@ -115,7 +115,8 @@ namespace Serilog.Sinks
                 $"https://{workspaceId}.ods.opinsights.{offeringDomain}/api/logs?api-version=2016-04-01");
         }
 
-        internal AzureLogAnalyticsSink(string workSpaceId,
+        internal AzureLogAnalyticsSink(
+            string workSpaceId,
             string authenticationId,
             string logName,
             bool storeTimestampInUtc,

--- a/src/Serilog.Sinks.AzureAnalytics/Sinks/AzureAnalytics/ConfigurationSettings.cs
+++ b/src/Serilog.Sinks.AzureAnalytics/Sinks/AzureAnalytics/ConfigurationSettings.cs
@@ -7,6 +7,7 @@ namespace Serilog.Sinks.AzureAnalytics
         private int _logBufferSize = 25_000;
         private int _batchSize = 100;
         private string _logName = "DiagnosticsLog";
+        private string _resourceId = null;
         public bool StoreTimestampInUtc = false;
         public IFormatProvider FormatProvider;
         public AzureOfferingType AzureOfferingType = AzureOfferingType.Public;
@@ -30,7 +31,15 @@ namespace Serilog.Sinks.AzureAnalytics
             set => _logName = string.IsNullOrWhiteSpace(value) ? "DiagnosticsLog" : value;
         }
 
+        public string ResourceId
+        {
+            get => _resourceId;
+            set => _resourceId = string.IsNullOrWhiteSpace(value) ? null : value;
+        }
+
         public bool Flatten { get; set; }
+
+        public bool SetTimeGenerated { get; set; }
     }
 
     public enum NamingStrategy


### PR DESCRIPTION
Add support for the `time-generated-field` and `x-ms-AzureResourceId` headers as defined in the [documentation](https://docs.microsoft.com/en-us/azure/azure-monitor/logs/data-collector-api#request-headers).