### PR TITLE
Added StringComparison.OrdinalIgnoreCase for LogPropertyName

### DIFF
--- a/src/Serilog.Sinks.AzureAnalytics/Sinks/Extensions/JsonExtensions.cs
+++ b/src/Serilog.Sinks.AzureAnalytics/Sinks/Extensions/JsonExtensions.cs
@@ -30,7 +30,7 @@ namespace Serilog.Sinks.Extensions
                 return jsonObject;
             }
 
-            var logPropToken = jsonObject.GetValue(LogPropertyName);
+            var logPropToken = jsonObject.GetValue(LogPropertyName, System.StringComparison.OrdinalIgnoreCase);
             jsonObject.Remove(LogPropertyName);
 
             jsonObject.Add(LogPropertyName, logPropToken.ToString(Newtonsoft.Json.Formatting.None, null));


### PR DESCRIPTION
Getting the LogPropertyName will no longer fail if there is a different naming strategy for the JSON properties.