### PR TITLE
Add support for Azure Token Credentials

### DIFF
--- a/src/Serilog.Sinks.AzureLogAnalytics.csproj
+++ b/src/Serilog.Sinks.AzureLogAnalytics.csproj
@@ -44,6 +44,7 @@
         <Version>$(Version)-$(VersionSuffix)</Version>
     </PropertyGroup>
     <ItemGroup>
+        <PackageReference Include="Azure.Core" Version="1.37.0" />
         <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="Serilog" Version="3.1.1" />

--- a/src/Sinks/AzureLogAnalytics/AzureLogAnalyticsSink.cs
+++ b/src/Sinks/AzureLogAnalytics/AzureLogAnalyticsSink.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Azure.Core;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
@@ -124,6 +125,14 @@ namespace Serilog.Sinks
         }
         private async Task<JToken> GetAuthToken()
         {
+            if (_loggerCredential.TokenCredential != null)
+            {
+                var tokenContext = new TokenRequestContext(new String[] { scope });
+                var cancellationToken = new CancellationToken();
+                var access_token = await _loggerCredential.TokenCredential.GetTokenAsync(tokenContext, cancellationToken);
+                return access_token.Token;
+            }
+
             var uri = $"https://login.microsoftonline.com/{_loggerCredential.TenantId}/oauth2/v2.0/token";
 
             var content = new FormUrlEncodedContent(new[]{

--- a/src/Sinks/AzureLogAnalytics/LoggerCredential.cs
+++ b/src/Sinks/AzureLogAnalytics/LoggerCredential.cs
@@ -1,3 +1,4 @@
+using Azure.Core;
 using System;
 
 namespace Serilog.Sinks.AzureLogAnalytics
@@ -10,5 +11,6 @@ namespace Serilog.Sinks.AzureLogAnalytics
         public String TenantId { get; set; }
         public String ClientId { get; set; }
         public String ClientSecret { get; set; }
+        public TokenCredential TokenCredential { get; set; }
     }
 }


### PR DESCRIPTION
I've added support for Azure Token Credentials in options as an alternative to providing a client ID and secret. This allows utilising Azure Managed Identity to connect azure deployed applications as well as other credetnial providers supported in the [Azure.Identity library](https://learn.microsoft.com/en-us/dotnet/api/azure.identity?view=azure-dotnet)

### Example Configuration
```
    var logger = new LoggerConfiguration()
        .WriteTo.AzureLogAnalytics(
            new LoggerCredential() {
                Endpoint = "*******",
                ImmutableId = "*******",
                StreamName = "*******",
                TokenCredential = new DefaultAzureCredential()
            }, new ConfigurationSettings())
        .CreateLogger();
```