### PR TITLE
Bug Fixes and JSON Formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ Log.Logger = new LoggerConfiguration()
     .CreateLogger();
 ```
 
+### Formatting event JSON
+
+To adjust the format of the event JSON populated into Azure Log Analytics, pass an `ITextFormatter` as the first argument:
+```
+Log.Logger = new LoggerConfiguration()
+    .WriteTo.AzureLogAnalytics(new CompactJsonFormatter(), <credentials>, <configSettings>)
+    .CreateLogger();
+```
+
 ## JSON appsettings configuration
 
 

--- a/src/LoggerConfigurationExtensions.cs
+++ b/src/LoggerConfigurationExtensions.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Serilog.Configuration;
+using Serilog.Formatting;
 using Serilog.Sinks;
 using Serilog.Sinks.AzureLogAnalytics;
 
@@ -34,7 +35,25 @@ namespace Serilog
                 configSettings = new ConfigurationSettings();
             }
             return loggerConfiguration.Sink(
-                new AzureLogAnalyticsSink(credentials, configSettings),
+                new AzureLogAnalyticsSink(credentials, configSettings, null),
+                restrictedToMinimumLevel: configSettings.MinLogLevel,
+                levelSwitch: configSettings.LevelSwitch
+            );
+        }
+
+        public static LoggerConfiguration AzureLogAnalytics(
+            this LoggerSinkConfiguration loggerConfiguration,
+            ITextFormatter formatter,
+            LoggerCredential credentials,
+            ConfigurationSettings configSettings
+)
+        {
+            if (configSettings == null)
+            {
+                configSettings = new ConfigurationSettings();
+            }
+            return loggerConfiguration.Sink(
+                new AzureLogAnalyticsSink(credentials, configSettings, formatter),
                 restrictedToMinimumLevel: configSettings.MinLogLevel,
                 levelSwitch: configSettings.LevelSwitch
             );

--- a/src/LoggerConfigurationExtensions.cs
+++ b/src/LoggerConfigurationExtensions.cs
@@ -29,8 +29,12 @@ namespace Serilog
             ConfigurationSettings configSettings
         )
         {
+            if (configSettings == null)
+            {
+                configSettings = new ConfigurationSettings();
+            }
             return loggerConfiguration.Sink(
-                new AzureLogAnalyticsSink(credentials, configSettings = new ConfigurationSettings()),
+                new AzureLogAnalyticsSink(credentials, configSettings),
                 restrictedToMinimumLevel: configSettings.MinLogLevel,
                 levelSwitch: configSettings.LevelSwitch
             );

--- a/src/Sinks/AzureLogAnalytics/AzureLogAnalyticsSink.cs
+++ b/src/Sinks/AzureLogAnalytics/AzureLogAnalyticsSink.cs
@@ -30,6 +30,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using NamingStrategy = Serilog.Sinks.AzureLogAnalytics.NamingStrategy;
 using System.Text.Json.Serialization;
+using Serilog.Formatting;
 
 namespace Serilog.Sinks
 {
@@ -45,7 +46,7 @@ namespace Serilog.Sinks
 
         const string scope = "https://monitor.azure.com//.default";
 
-        internal AzureLogAnalyticsSink(LoggerCredential loggerCredential, ConfigurationSettings settings) :
+        internal AzureLogAnalyticsSink(LoggerCredential loggerCredential, ConfigurationSettings settings, ITextFormatter formatter) :
             base(settings.BatchSize, settings.BufferSize)
         {
             _semaphore = new SemaphoreSlim(1, 1);
@@ -72,6 +73,7 @@ namespace Serilog.Sinks
 
             _jsonOptions.ReferenceHandler = ReferenceHandler.IgnoreCycles;
             _jsonOptions.WriteIndented = false;
+            _jsonOptions.Converters.Add(new LoggerJsonConverter(formatter));
             if (_configurationSettings.MaxDepth > 0)
             {
                 _configurationSettings.MaxDepth = _configurationSettings.MaxDepth;

--- a/src/Sinks/AzureLogAnalytics/AzureLogAnalyticsSink.cs
+++ b/src/Sinks/AzureLogAnalytics/AzureLogAnalyticsSink.cs
@@ -111,6 +111,7 @@ namespace Serilog.Sinks
                     var obj = new ExpandoObject() as IDictionary<string, object>;
                     obj.Add("TimeGenerated", DateTime.UtcNow);
                     obj.Add("Event", s);
+                    obj.Add("Message", s.RenderMessage());
                     return obj;
                 });
 

--- a/src/Sinks/AzureLogAnalytics/LoggerJsonConverter.cs
+++ b/src/Sinks/AzureLogAnalytics/LoggerJsonConverter.cs
@@ -1,0 +1,36 @@
+﻿using Serilog.Events;
+using Serilog.Formatting;
+using Serilog.Formatting.Json;
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Serilog.Sinks.AzureLogAnalytics
+{
+    internal class LoggerJsonConverter : JsonConverter<LogEvent>
+    {
+        private readonly ITextFormatter _formatter;
+        public LoggerJsonConverter(ITextFormatter formatter)
+        {
+            if (formatter != null)
+            {
+                _formatter = formatter;
+            } else
+            {
+                _formatter = new JsonFormatter();
+            }
+        }
+        public override LogEvent Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Write(Utf8JsonWriter writer, LogEvent value, JsonSerializerOptions options)
+        {
+            var jsonString = new StringWriter();
+            _formatter.Format(value, jsonString);
+            writer.WriteRawValue(jsonString.ToString());
+        }
+    }
+}


### PR DESCRIPTION
In my attempts to get this working in my project I encountered a few problems. I've included my solutions here for consideration.
1. My logs included the message template, but not the rendered message - To resolve I've added the rendered message to the payload send to LA
2. I was unable to set configuration settings (initially found when trying to adjust the JSON Serializer) - I've passed on the configuration settings provided by the caller and only create a new one if none is provided by the calling code.
3. The `System.Text.JSON` serializer was not able to serialize the `Serilog.LogEventProperty` objects meaning the log property values were missing from my logs. - I've added support for using one of the JSON Formatters (with the `ITextFormatter` interface) provided by Serilog to format the JSON sent to LA

Note that point 3 does significantly change the format of the event sent to LA, however I believe it was previously failing to send much of the information.