### PR TITLE
Improve third party references

### DIFF
--- a/src/Serilog.Sinks.AzureLogAnalytics.csproj
+++ b/src/Serilog.Sinks.AzureLogAnalytics.csproj
@@ -44,11 +44,10 @@
         <Version>$(Version)-$(VersionSuffix)</Version>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Azure.Core" Version="1.39.0" />
-        <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+        <PackageReference Include="Azure.Core" Version="1.42.0" />
         <PackageReference Include="Serilog" Version="3.1.1" />
-        <PackageReference Include="System.Net.Http" Version="4.3.4" />
-        <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
-        <PackageReference Include="System.Text.Json" Version="8.0.3" />
     </ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+		<PackageReference Include="System.Text.Json" Version="8.0.4" />
+	</ItemGroup>
 </Project>


### PR DESCRIPTION
-- Reference System.Text.Json only for netstandard2.0. In .NET 8 is already included in runtime
-- Remove System.Net.Http: not used
-- Remove System.Net.Http.Json: not used
-- Update System.Text.Json from 8.0.3 to 8.0.4: Fix CVE-2024-30105 
-- Update Azure.Core from 1.39.0 to 1.42.0