### PR TITLE
Documentation refers to non-deprecated NuGet package

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ High performance Serilog sink that writes to Azure Log Analytics. It supports au
 Install [Serilog.Sinks.AzureAnalytics](https://www.nuget.org/packages/serilog.sinks.azureanalytics) from NuGet
 
 ```PowerShell
-Install-Package Serilog.Sinks.AzureAnalytics
+Install-Package Serilog.Sinks.AzureLogAnalytics
 ```
 
 Configure logger by calling `WriteTo.AzureLogAnalytics(<workspaceId>, <authenticationId>)`


### PR DESCRIPTION
Hi,
I got mad trying to understand why this sink failed to work, until I noticed that the documentation still refers to:

`Serilog.Sinks.AzureAnalytics`

instead of to:

`Serilog.Sinks.AzureLogAnalytics`

The former has been deprecated. The latter is the new version.

I did not check if all the other details in `README.md` are 100% compatible with the new major release.



See more details in https://github.com/serilog/serilog/issues/2122