### PR TITLE
Typo: engra -> entra

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ immutableId:  ImmutableId for Data Collection Rules (DCR)
 streamName:   Output stream name of target (Log Analytics API, can be accessed from DCR)
 tenantId:     Directory (tenant) Id of registered application (Microsoft Entra ID)
 clientId:     Application (client) Id of Microsoft Entra application
-clientSecret: Client secret for registered Engra Application  
+clientSecret: Client secret for registered Entra Application  
 ```
 >
 


### PR DESCRIPTION
There is a little typo in the README, egra instead of entra. This PR fixes it.