### PR TITLE
Missing Final Logs During Proper Disposal

### DIFF
--- a/src/Sinks/Batch/BatchProvider.cs
+++ b/src/Sinks/Batch/BatchProvider.cs
@@ -198,14 +198,14 @@ namespace Serilog.Sinks.Batch
                     foreach (var logEvent in _batchEventsCollection)
                     {
                         SelfLog.WriteLine($"Sending batch of {logEvent.Count} logs");
-                        Task.Run(()=> WriteLogEventAsync(logEvent).GetAwaiter().GetResult());
+                        WriteLogEventAsync(logEvent).GetAwaiter().GetResult();
                     }
                 }
 
                 if (!_eventsCollection.IsCompleted)
                 {
                     SelfLog.WriteLine($"Sending batch of {_eventsCollection.Count} logs");
-                    Task.Run(()=> WriteLogEventAsync(_eventsCollection.ToList()).GetAwaiter().GetResult());
+                    WriteLogEventAsync(_eventsCollection.ToList()).GetAwaiter().GetResult();
                 }
 
             }


### PR DESCRIPTION
Addresses #72 by re-implementing the dispose logic to be synchronous instead of being asynchronous.

How this currently works is it fires off new threads to write the last couple of logs within the batch. The main thread is then able to process through the rest of the dispose logic. This then turns into a race case, where sometimes the threads handling the last couple of log messages are able to get them up in time, while in other cases the program exits prior to the last couple of log messages get sent up to Azure.

To fix this we instead have it just process all the requests on the main thread handling the Dispose call so it makes sure that the last batch of logs are able to be processed prior to the application exiting.